### PR TITLE
Bump agent version for background proc support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
   version: 
     description: 'The version of Orbit CI binaries to install.'
     required: false
-    default: 'v0.9.6'
+    default: 'v0.9.7'
 
 outputs:
   version:

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -34477,6 +34477,7 @@ async function startOrbitd(pathToCLI, serverAddr, apiToken) {
       `-api-address=${serverAddr}`,
       `-api-token=${apiToken}`,
       '-bpf-loglevel=1',
+      '-ci-provider=github',
       '-debug',
       `-logfile=${logFile}`
     ], {

--- a/src/setup.js
+++ b/src/setup.js
@@ -95,6 +95,7 @@ async function startOrbitd(pathToCLI, serverAddr, apiToken) {
       `-api-address=${serverAddr}`,
       `-api-token=${apiToken}`,
       '-bpf-loglevel=1',
+      '-ci-provider=github',
       '-debug',
       `-logfile=${logFile}`
     ], {


### PR DESCRIPTION
- Pass ci provider label now required by the agent