### PR TITLE
Add support for env var allowlist

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,12 @@ inputs:
   version: 
     description: 'The version of Orbit CI binaries to install.'
     required: false
-    default: 'v0.9.9'
+    default: 'v0.10.0'
+
+  env_allowlist:
+    description: 'List of allowed user defined environment variables'
+    required: false
+    default: ''
 
 outputs:
   version:

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -34685,6 +34685,7 @@ async function run() {
   const apiToken = core.getInput('orbitci_api_token', { required: true });
   const serverAddr = core.getInput('orbitci_server_addr');
   const version = core.getInput('version');
+  const envAllowlist = core.getInput('env_allowlist');
   const githubToken = process.env.GITHUB_TOKEN;
   if (!githubToken) {
     core.setFailed("GITHUB_TOKEN is not set in the environment.");
@@ -34695,6 +34696,8 @@ async function run() {
 
   await setJobIDEnvvar(octokit);
   core.debug(`environment variable ORBITCI_JOB_ID set to: ${process.env.ORBITCI_JOB_ID}`);
+
+  core.exportVariable('ORBITCI_ENV_ALLOWLIST', envAllowlist);
 
   const supportedPlatforms = ['linux'];
   if (!supportedPlatforms.includes(platform.platform)) {

--- a/src/setup.js
+++ b/src/setup.js
@@ -303,6 +303,7 @@ async function run() {
   const apiToken = core.getInput('orbitci_api_token', { required: true });
   const serverAddr = core.getInput('orbitci_server_addr');
   const version = core.getInput('version');
+  const envAllowlist = core.getInput('env_allowlist');
   const githubToken = process.env.GITHUB_TOKEN;
   if (!githubToken) {
     core.setFailed("GITHUB_TOKEN is not set in the environment.");
@@ -313,6 +314,8 @@ async function run() {
 
   await setJobIDEnvvar(octokit);
   core.debug(`environment variable ORBITCI_JOB_ID set to: ${process.env.ORBITCI_JOB_ID}`);
+
+  core.exportVariable('ORBITCI_ENV_ALLOWLIST', envAllowlist);
 
   const supportedPlatforms = ['linux'];
   if (!supportedPlatforms.includes(platform.platform)) {


### PR DESCRIPTION
- Adds new action input to specify the allowed env vars whose value is captured and propagated as span attribute by the agent.
- Bump agent version that supports user defined env var propagation