### PR TITLE
Migrate to Orbit CLI usage

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,10 +12,15 @@ inputs:
     description: 'The API token used to publish events to Orbit CI'
     required: true
 
-  version: 
+  version:
     description: 'The version of Orbit CI binaries to install.'
     required: false
-    default: 'v0.10.1'
+    default: 'v0.11.0'
+
+  releases_repo:
+    description: 'The repository name containing Orbit CI release artifacts'
+    required: false
+    default: 'releases'
 
   env_allowlist:
     description: |

--- a/dist/teardown/index.js
+++ b/dist/teardown/index.js
@@ -27558,54 +27558,10 @@ var __webpack_exports__ = {};
 const core = __nccwpck_require__(7484);
 const fs = __nccwpck_require__(9896);
 const { spawn } = __nccwpck_require__(5317);
-const path = __nccwpck_require__(6928);
-
-async function stopUsdtServer() {
-  return new Promise((resolve, reject) => {
-    // First check if the PID file exists
-    if (!fs.existsSync('/tmp/orbit/orbit_usdt.pid')) {
-      core.debug('USDT server PID file not found, server may not be running');
-      resolve();
-      return;
-    }
-
-    const usdtServer = spawn('orbit-usdt', ['server', 'stop']);
-
-    let output = '';
-    usdtServer.stdout.on('data', (data) => {
-      output += data.toString();
-    });
-
-    usdtServer.stderr.on('data', (data) => {
-      core.debug(`USDT server stop stderr: ${data}`);
-    });
-
-    usdtServer.on('exit', (code) => {
-      if (code === 0) {
-        core.debug(`USDT server stop output: ${output.trim()}`);
-        // Verify the PID file is removed
-        setTimeout(() => {
-          if (!fs.existsSync('/tmp/orbit/orbit_usdt.pid')) {
-            core.debug('USDT server PID file removed, server stopped successfully');
-            resolve();
-          } else {
-            reject(new Error('PID file still exists after stop command'));
-          }
-        }, 1000);
-      } else {
-        reject(new Error(`Command failed with exit code ${code}`));
-      }
-    });
-
-    usdtServer.on('error', (err) => {
-      reject(err);
-    });
-  });
-}
 
 async function triggerJobEnd(jobId, serverAddr, apiToken) {
   return new Promise((resolve, reject) => {
-    const orbit = spawn('orbit-usdt', [
+    const orbit = spawn('orbit', [
       'fire', 
       'job-end', 
       `-job-id=${jobId}`,
@@ -27672,14 +27628,6 @@ async function run() {
     core.info('✅ Job end event sent successfully');
   } catch (error) {
     core.warning(`Failed to send job end event: ${error.message}`);
-  }
-
-  // Stop USDT server
-  try {
-    await stopUsdtServer();
-    core.info('✅ USDT server stopped successfully');
-  } catch (error) {
-    core.warning(`Failed to stop USDT server: ${error.message}`);
   }
 
   // Stop agent

--- a/package.json
+++ b/package.json
@@ -2,15 +2,12 @@
   "name": "github-action",
   "version": "1.0.0",
   "description": "A GitHub Action built with JavaScript",
-  "main": "index.js",
   "scripts": {
     "clean": "rm -rf dist",
     "build": "npm run clean && ncc build src/setup.js -o dist/setup && ncc build src/teardown.js -o dist/teardown",
     "prepare": "npm run build",
     "orbit:setup": "node dist/setup/index.js",
-    "orbit:teardown": "node dist/teardown/index.js",
-    "test": "jest",
-    "lint": "eslint ."
+    "orbit:teardown": "node dist/teardown/index.js"
   },
   "keywords": [
     "GitHub",
@@ -21,13 +18,9 @@
   "dependencies": {
     "@actions/core": "^1.11.1",
     "@actions/github": "^6.0.0",
-    "@actions/tool-cache": "^2.0.1",
-    "pnpm": "^10.4.1",
-    "tar": "^6.2.0"
+    "@actions/tool-cache": "^2.0.1"
   },
   "devDependencies": {
-    "@vercel/ncc": "^0.38.3",
-    "eslint": "^9.20.1",
-    "jest": "^29.7.0"
+    "@vercel/ncc": "^0.38.3"
   }
 }

--- a/src/setup.js
+++ b/src/setup.js
@@ -7,17 +7,16 @@ const fs = require('fs');
 const path = require('path');
 
 const ORBITCI_ORG = "orbitci";
-const ORBITCI_AGENT_REPO = "orbit-agent-releases";
 const RUNNER_DIR = "/home/runner";
 const LOG_REGEX = "Worker_*.log";
 
-async function downloadRelease(octokit, version) {
+async function downloadRelease(octokit, version, releasesRepo) {
   let releaseTag = version;
   if (version === 'latest') {
     core.debug('Fetching latest release tag ...');
     const latestRelease = await octokit.rest.repos.getLatestRelease({
       owner: ORBITCI_ORG,
-      repo: ORBITCI_AGENT_REPO
+      repo: releasesRepo
     });
     releaseTag = latestRelease.data.tag_name;
     core.debug(`Latest release tag: ${releaseTag}`);
@@ -26,14 +25,14 @@ async function downloadRelease(octokit, version) {
   core.debug(`Fetching release: ${releaseTag}`);
   const release = await octokit.rest.repos.getReleaseByTag({
     owner: ORBITCI_ORG,
-    repo: ORBITCI_AGENT_REPO,
+    repo: releasesRepo,
     tag: releaseTag
   });
 
   return { release, releaseTag };
 }
 
-async function setupBinaries(release, githubToken, octokit) {
+async function setupBinaries(release, githubToken) {
   const version = release.data.tag_name;
   const assetName = `orbit-${version}-github-${platform.platform}-${platform.arch}.tar.gz`;
 
@@ -46,21 +45,12 @@ async function setupBinaries(release, githubToken, octokit) {
 
   core.debug(`Processing ${assetName}...`);
 
-  const assetData = await octokit.rest.repos.getReleaseAsset({
-    owner: ORBITCI_ORG,
-    repo: ORBITCI_AGENT_REPO,
-    asset_id: asset.id,
-    headers: {
-      Accept: 'application/octet-stream'
-    }
-  });
-
   const downloadPath = await tc.downloadTool(
-    assetData.url,
+    asset.url,
     undefined,
     `token ${githubToken}`,
     {
-      'Accept': 'application/octet-stream'
+      accept: 'application/octet-stream'
     }
   );
 
@@ -80,8 +70,7 @@ async function setupBinaries(release, githubToken, octokit) {
 async function startOrbitd(pathToCLI, serverAddr, apiToken) {
   // Use absolute paths for sudo commands to work
   const orbitdPath = path.join(pathToCLI, 'orbitd');
-  const orbitUsdtPath = path.join(pathToCLI, 'orbit-usdt');
-  const logFile="/var/log/orbitd.log";
+  const logFile = "/var/log/orbitd.log";
 
   return new Promise((resolve, reject) => {
     const timeout = setTimeout(() => {
@@ -91,7 +80,6 @@ async function startOrbitd(pathToCLI, serverAddr, apiToken) {
     const orbitd = spawn('sudo', [
       '-E',
       orbitdPath,
-      `-usdt-bin=${orbitUsdtPath}`,
       `-api-address=${serverAddr}`,
       `-api-token=${apiToken}`,
       '-bpf-loglevel=1',
@@ -129,83 +117,21 @@ async function startOrbitd(pathToCLI, serverAddr, apiToken) {
       core.debug(`orbitd exited with code ${code} and signal ${signal}`);
       clearTimeout(timeout);
       if (code !== null) {
-        reject(new Error(`orbitd exited with code ${code}. Check ${logFile} for errors`));
+        let errorMessage = `orbitd exited with code ${code}`;
+        try {
+          if (fs.existsSync(logFile)) {
+            const logContents = fs.readFileSync(logFile, 'utf8');
+            errorMessage += `\n\nLog file contents:\n${logContents}`;
+          } else {
+            errorMessage += `\n\nLog file ${logFile} does not exist`;
+          }
+        } catch (readError) {
+          errorMessage += `\n\nFailed to read log file ${logFile}: ${readError.message}`;
+        }
+        reject(new Error(errorMessage));
       } else if (signal !== null) {
         reject(new Error(`orbitd was terminated by signal ${signal}`));
       }
-    });
-  });
-}
-
-async function startUsdtServer() {
-  return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      reject(new Error('Timeout waiting for USDT server to start'));
-    }, 5000);
-
-    const usdtServer = spawn('orbit-usdt', ['server', 'start'], {
-      detached: true,
-      stdio: 'ignore',
-      shell: false,
-    });
-
-    usdtServer.on('error', (err) => {
-      core.debug(`USDT server error: ${err.message}`);
-      clearTimeout(timeout);
-      reject(new Error(`Failed to start USDT server: ${err.message}`));
-    });
-
-    usdtServer.on('spawn', async () => {
-      core.debug('USDT server spawned');
-      clearTimeout(timeout);
-
-      core.saveState('usdtServerPid', usdtServer.pid.toString());
-      usdtServer.unref();  // Allows parent to exit independently
-
-      // Wait additional 2 seconds for the process to be ready
-      core.debug('Waiting 2 seconds for USDT server to be ready...');
-      await new Promise(resolve => setTimeout(resolve, 2000));
-      core.debug('USDT server ready wait completed');
-
-      resolve(usdtServer.pid.toString());
-    });
-
-    usdtServer.on('exit', (code, signal) => {
-      core.debug(`USDT server exited with code ${code} and signal ${signal}`);
-      clearTimeout(timeout);
-      if (code !== null) {
-        reject(new Error(`USDT server exited with code ${code}`));
-      } else if (signal !== null) {
-        reject(new Error(`USDT server was terminated by signal ${signal}`));
-      }
-    });
-  });
-}
-
-async function triggerJobStart(jobId) {
-  return new Promise((resolve, reject) => {
-    const orbit = spawn('orbit-usdt', ['fire', 'job-start', '-job-id', jobId]);
-
-    let output = '';
-    orbit.stdout.on('data', (data) => {
-      output += data.toString();
-    });
-
-    orbit.stderr.on('data', (data) => {
-      core.debug(`orbit command stderr: ${data}`);
-    });
-
-    orbit.on('exit', (code) => {
-      if (code === 0) {
-        core.debug(`orbit command output: ${output.trim()}`);
-        resolve();
-      } else {
-        reject(new Error(`orbit command failed with exit code ${code}`));
-      }
-    });
-
-    orbit.on('error', (err) => {
-      reject(new Error(`Failed to execute orbit command: ${err.message}`));
     });
   });
 }
@@ -303,6 +229,7 @@ async function run() {
   const apiToken = core.getInput('orbitci_api_token', { required: true });
   const serverAddr = core.getInput('orbitci_server_addr');
   const version = core.getInput('version');
+  const releasesRepo = core.getInput('releases_repo');
   const envAllowlist = core.getInput('env_allowlist');
   const githubToken = process.env.GITHUB_TOKEN;
   if (!githubToken) {
@@ -326,24 +253,14 @@ async function run() {
     throw new Error(`Architecture ${platform.arch} is not supported. Currently, this action only supports: ${supportedArchs.join(', ')}`);
   }
 
-  const { release, releaseTag } = await downloadRelease(octokit, version);
+  const { release, releaseTag } = await downloadRelease(octokit, version, releasesRepo);
   core.info(`📦 Downloaded Orbit CI binaries version: ${releaseTag}`);
 
-  const pathToCLI = await setupBinaries(release, githubToken, octokit);
+  const pathToCLI = await setupBinaries(release, githubToken);
   core.addPath(pathToCLI);
 
   const pid = await startOrbitd(pathToCLI, serverAddr, apiToken);
   core.info(`✅ Orbit CI agent started successfully (PID: ${pid})`);
-
-  const usdtPid = await startUsdtServer();
-  core.info(`✅ Orbit USDT server started successfully (PID: ${usdtPid})`);
-
-  const jobId = process.env.GITHUB_JOB;
-  if (!jobId) {
-    throw new Error('GITHUB_JOB environment variable is required');
-  }
-  await triggerJobStart(jobId);
-  core.info('✅ Job start event sent successfully');
 
   core.setOutput('version', releaseTag);
 }

--- a/src/teardown.js
+++ b/src/teardown.js
@@ -1,54 +1,10 @@
 const core = require('@actions/core');
 const fs = require('fs');
 const { spawn } = require('child_process');
-const path = require('path');
-
-async function stopUsdtServer() {
-  return new Promise((resolve, reject) => {
-    // First check if the PID file exists
-    if (!fs.existsSync('/tmp/orbit/orbit_usdt.pid')) {
-      core.debug('USDT server PID file not found, server may not be running');
-      resolve();
-      return;
-    }
-
-    const usdtServer = spawn('orbit-usdt', ['server', 'stop']);
-
-    let output = '';
-    usdtServer.stdout.on('data', (data) => {
-      output += data.toString();
-    });
-
-    usdtServer.stderr.on('data', (data) => {
-      core.debug(`USDT server stop stderr: ${data}`);
-    });
-
-    usdtServer.on('exit', (code) => {
-      if (code === 0) {
-        core.debug(`USDT server stop output: ${output.trim()}`);
-        // Verify the PID file is removed
-        setTimeout(() => {
-          if (!fs.existsSync('/tmp/orbit/orbit_usdt.pid')) {
-            core.debug('USDT server PID file removed, server stopped successfully');
-            resolve();
-          } else {
-            reject(new Error('PID file still exists after stop command'));
-          }
-        }, 1000);
-      } else {
-        reject(new Error(`Command failed with exit code ${code}`));
-      }
-    });
-
-    usdtServer.on('error', (err) => {
-      reject(err);
-    });
-  });
-}
 
 async function triggerJobEnd(jobId, serverAddr, apiToken) {
   return new Promise((resolve, reject) => {
-    const orbit = spawn('orbit-usdt', [
+    const orbit = spawn('orbit', [
       'fire', 
       'job-end', 
       `-job-id=${jobId}`,
@@ -115,14 +71,6 @@ async function run() {
     core.info('✅ Job end event sent successfully');
   } catch (error) {
     core.warning(`Failed to send job end event: ${error.message}`);
-  }
-
-  // Stop USDT server
-  try {
-    await stopUsdtServer();
-    core.info('✅ USDT server stopped successfully');
-  } catch (error) {
-    core.warning(`Failed to stop USDT server: ${error.message}`);
   }
 
   // Stop agent


### PR DESCRIPTION
Orbit CI agent deployment and startup becomes simpler with the removal of the USDT server startup and teardown, which is no longer necessary. The `orbit-usdt` binary is renamed to `orbit` and manages any userspace operations.

List of changes
- Use Orbit CLI instead of the usdt binary
- Remove managing of USDT server from the pipeline
- Remove sending Job start signal (this is automatically handled by the backend)
- Download releases from new repo with minor enhancements
- Unused code/dependencies cleanup
- Use new agent version (with kernel 6.5+ support fix)
- Log the contents of the agent log file when the agent fails to start